### PR TITLE
DD-218:dd-dans-deposit-to-dataverse fails at publish when dataset is locked

### DIFF
--- a/examples/src/main/java/nl/knaw/dans/examplesjava/BaseApp.java
+++ b/examples/src/main/java/nl/knaw/dans/examplesjava/BaseApp.java
@@ -32,7 +32,7 @@ public class BaseApp {
     try {
 
       PropertiesConfiguration props = new PropertiesConfiguration("dataverse.properties");
-      server = new DataverseInstance(new DataverseInstanceConfig(new URI(props.getString("baseUrl")), props.getString("apiKey"), new Some<String>(props.getString("unblockKey")),  new Some<String>(props.getString("builtinUserKey")), 5000, 300000, "1"));
+      server = new DataverseInstance(new DataverseInstanceConfig(new URI(props.getString("baseUrl")), props.getString("apiKey"), new Some<String>(props.getString("unblockKey")),  new Some<String>(props.getString("builtinUserKey")), 5000, 300000, "1", 10, 500));
     }
     catch (ConfigurationException e) {
       e.printStackTrace();

--- a/examples/src/main/scala/nl/knaw/dans/examples/BaseApp.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/BaseApp.scala
@@ -29,7 +29,9 @@ trait BaseApp extends DebugEnhancedLogging{
       baseUrl = new URI(props.getString("baseUrl")),
       apiToken = props.getString("apiKey"),
       unblockKey = Option(props.getString("unblockKey")),
-      builtinUserKey = Option(props.getString("builtinUserKey"))
+      builtinUserKey = Option(props.getString("builtinUserKey")),
+      lockedRetryTimes = props.getInt("lockedRetryTimes"),
+      lockedRetryInterval = props.getInt("lockedRetryInterval")
     )
   )
 

--- a/examples/src/main/scala/nl/knaw/dans/examples/GetLocks.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/GetLocks.scala
@@ -28,7 +28,7 @@ object GetLocks extends App with DebugEnhancedLogging with BaseApp {
    */
   for (_ <- Range(1, 300)) {
     for {
-      response <- server.dataset(persistentId).getLockings
+      response <- server.dataset(persistentId).getLocks
       locks <- response.data
       _ = if (locks.nonEmpty)
             logger.info(s"Dataset is currently locked by: ${

--- a/examples/src/main/scala/nl/knaw/dans/examples/GetLocks.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/GetLocks.scala
@@ -28,7 +28,7 @@ object GetLocks extends App with DebugEnhancedLogging with BaseApp {
    */
   for (_ <- Range(1, 300)) {
     for {
-      response <- server.dataset(persistentId).getLocks
+      response <- server.dataset(persistentId).getLockings
       locks <- response.data
       _ = if (locks.nonEmpty)
             logger.info(s"Dataset is currently locked by: ${

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/AdminApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/AdminApi.scala
@@ -32,6 +32,8 @@ class AdminApi private[dataverse](configuration: DataverseInstanceConfig) extend
   protected val builtinUserKey: Option[String] = Option.empty
   protected val apiPrefix: String = ""
   protected val apiVersion: Option[String] = Option.empty // No version allowed here
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   /**
    * Returns the account data for a single user.

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/BuiltinUserApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/BuiltinUserApi.scala
@@ -41,6 +41,8 @@ class BuiltinUserApi private[dataverse](configuration: DataverseInstanceConfig) 
   protected val builtinUserKey: Option[String] = configuration.builtinUserKey
   protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   /**
    * @see [[https://guides.dataverse.org/en/5.2/api/native-api.html#create-a-builtin-user]]

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
@@ -44,6 +44,8 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
   protected val builtinUserKey: Option[String] = Option.empty
   protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   protected val targetBase: String = "datasets"
   protected val id: String = datasetId

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseApi.scala
@@ -35,6 +35,8 @@ class DataverseApi private[dataverse](dvId: String, configuration: DataverseInst
   protected val builtinUserKey: Option[String] = Option.empty
   protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   /**
    * Creates a dataverse base on a definition provided as model object.

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstanceConfig.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstanceConfig.scala
@@ -23,4 +23,7 @@ case class DataverseInstanceConfig(baseUrl: URI,
                                    builtinUserKey: Option[String] = None,
                                    connectionTimeout: Int = 5000,
                                    readTimeout: Int = 300000,
-                                   apiVersion: String = "1")
+                                   apiVersion: String = "1",
+                                   lockedRetryTimes: Int,
+                                   lockedRetryInterval: Int
+                                  )

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstanceConfig.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstanceConfig.scala
@@ -24,6 +24,6 @@ case class DataverseInstanceConfig(baseUrl: URI,
                                    connectionTimeout: Int = 5000,
                                    readTimeout: Int = 300000,
                                    apiVersion: String = "1",
-                                   lockedRetryTimes: Int,
-                                   lockedRetryInterval: Int
+                                   lockedRetryTimes: Int = 10,
+                                   lockedRetryInterval: Int = 500
                                   )

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/FileApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/FileApi.scala
@@ -38,6 +38,8 @@ class FileApi private[dataverse](filedId: String, isPersistentFileId: Boolean, c
   protected val builtinUserKey: Option[String] = Option.empty
   protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   protected val targetBase: String = "files"
   protected val id: String = filedId

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/SwordApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/SwordApi.scala
@@ -32,6 +32,8 @@ class SwordApi private[dataverse](configuration: DataverseInstanceConfig) extend
   protected val unblockKey: Option[String] = Option.empty
   protected val builtinUserKey: Option[String] = Option.empty
   protected val apiVersion: Option[String] = Option("1.1") // TODO: Make configurable?
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   /**
    * Deletes a file from the current draft of the dataset. To look up the databaseId use [[DatasetApi#listFiles]].

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/WorkflowsApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/WorkflowsApi.scala
@@ -31,6 +31,8 @@ class WorkflowsApi private[dataverse](configuration: DataverseInstanceConfig) ex
   protected val builtinUserKey: Option[String] = Option.empty
   protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
+  protected val lockedRetryTimes: Int = configuration.lockedRetryTimes
+  protected val lockedRetryInterval: Int = configuration.lockedRetryInterval
 
   def resume(invocationId: String): Try[DataverseResponse[Nothing]] = {
     postText(s"workflows/$invocationId", body = "")

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/package.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/package.scala
@@ -35,4 +35,8 @@ package object dataverse {
     if (pretty) Serialization.writePretty(o)
     else Serialization.write(o)
   }
+
+  case class LockException(msg: String, cause: Throwable = null)
+    extends Exception(s"$msg", cause)
+
 }


### PR DESCRIPTION
Fixes DD-218:

* `awaitUnlock` method is added in `DatasetApi`
* This method checks if dataset is locked, and if it is locked tries a few times anew, waiting in between the calls.
* The times of retries and the interval between retries is given in application properties

# How to test


# Related PRs 
* https://github.com/DANS-KNAW/dd-dans-deposit-to-dataverse/pull/24

# Notify
@DANS-KNAW/dataversedans

