### PR TITLE
DD-334 Add lock override header to Dataverse API calls from prepublish workflow

### DIFF
--- a/easy-dv/src/main/assembly/dist/cfg/application.properties
+++ b/easy-dv/src/main/assembly/dist/cfg/application.properties
@@ -6,7 +6,7 @@ dataverse.api-version=1
 dataverse.connection-timeout-ms=10000
 dataverse.read-timeout-ms=30000
 
-# The API is user specific and should normally set globally for easy-dv, otherwise
+# The API-key is user specific and should normally set globally for easy-dv, otherwise
 # every OS user will work with the same Dataverse account.
 # easy-dv will try to read the API-key first from one of the environment variables
 # DATAVERSE_API_KEY, DATAVERSE_API_TOKEN or API_TOKEN (the latter is supported for compatibility with the

--- a/easy-dv/src/main/scala/nl.knaw.dans.easydv/Configuration.scala
+++ b/easy-dv/src/main/scala/nl.knaw.dans.easydv/Configuration.scala
@@ -51,8 +51,8 @@ object Configuration {
         connectionTimeout = properties.getInt("dataverse.connection-timeout-ms"),
         readTimeout = properties.getInt("dataverse.read-timeout-ms"),
         apiVersion = properties.getString("dataverse.api-version"),
-        awaitUnlockMaxNumberOfRetries = properties.getInt("dataverse.await-unlock.max-retries"),
-        awaitUnlockMillisecondsBetweenRetries = properties.getInt("dataverse.await-unlock.wait-time-ms")
+        awaitLockStateMaxNumberOfRetries = properties.getInt("dataverse.await-unlock.max-retries"),
+        awaitLockStateMillisecondsBetweenRetries = properties.getInt("dataverse.await-unlock.wait-time-ms")
       )
     )
   }

--- a/examples/src/main/scala/nl/knaw/dans/examples/EditDatasetMetadata.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/EditDatasetMetadata.scala
@@ -24,13 +24,14 @@ object EditDatasetMetadata extends App with DebugEnhancedLogging with BaseApp {
   private implicit val jsonFormats: Formats = DefaultFormats
   private val persistentId = args(0)
   private val title = args(1)
+  private val optLockOverride = if (args.length > 2) Option(args(2)) else None
 
   private val fieldList: FieldList = FieldList(
     List(PrimitiveSingleValueField("title", s"$title"))
   )
 
   val result = for {
-    response <- server.dataset(persistentId).editMetadata(fieldList)
+    response <- server.dataset(persistentId, optLockOverride).editMetadata(fieldList)
     _ = logger.info(s"Raw response message: ${ response.string }")
     _ = logger.info(s"JSON AST: ${ response.json }")
     _ = logger.info(s"JSON serialized: ${ Serialization.writePretty(response.json) }")

--- a/examples/src/main/scala/nl/knaw/dans/examples/ResumeDataset.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/ResumeDataset.scala
@@ -15,29 +15,17 @@
  */
 package nl.knaw.dans.examples
 
-import nl.knaw.dans.examples.GetMetadataBlock.logger
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.json4s.{ DefaultFormats, Formats }
 
-object GetLocks extends App with DebugEnhancedLogging with BaseApp {
+object ResumeDataset extends App with DebugEnhancedLogging with BaseApp {
   private implicit val jsonFormats: Formats = DefaultFormats
-  private val persistentId = args(0)
+  private val invocationId = args(0)
+  private val fail = args.length > 2 && args(1) == "fail"
 
-  /*
-   * Start the example and then do something with the dataset that causes a lock, such as ingesting a
-   * tabular file.
-   */
-  for (_ <- Range(1, 300)) {
-    for {
-      response <- server.dataset(persistentId).getLocks
-      _ = debug(s"Raw response: ${ response.string }")
-      locks <- response.data
-      _ = if (locks.nonEmpty)
-            logger.info(s"Dataset is currently locked by: ${
-              if (locks.isEmpty) "NOTHING"
-              else locks.map(_.lockType).mkString(", ")
-            } ")
-    } yield ()
-    Thread.sleep(50)
-  }
+  val result = for {
+    response <- server.workflows().resume(invocationId, fail)
+    _ = logger.info(s"Raw response message: ${ response.string }")
+  } yield ()
+  logger.info(s"result = $result")
 }

--- a/examples/src/main/scala/nl/knaw/dans/examples/SetWorkflowsWhitelist.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/SetWorkflowsWhitelist.scala
@@ -15,29 +15,20 @@
  */
 package nl.knaw.dans.examples
 
-import nl.knaw.dans.examples.GetMetadataBlock.logger
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.json4s.native.Serialization
 import org.json4s.{ DefaultFormats, Formats }
 
-object GetLocks extends App with DebugEnhancedLogging with BaseApp {
+object SetWorkflowsWhitelist extends App with DebugEnhancedLogging with BaseApp {
   private implicit val jsonFormats: Formats = DefaultFormats
-  private val persistentId = args(0)
 
-  /*
-   * Start the example and then do something with the dataset that causes a lock, such as ingesting a
-   * tabular file.
-   */
-  for (_ <- Range(1, 300)) {
-    for {
-      response <- server.dataset(persistentId).getLocks
-      _ = debug(s"Raw response: ${ response.string }")
-      locks <- response.data
-      _ = if (locks.nonEmpty)
-            logger.info(s"Dataset is currently locked by: ${
-              if (locks.isEmpty) "NOTHING"
-              else locks.map(_.lockType).mkString(", ")
-            } ")
-    } yield ()
-    Thread.sleep(50)
-  }
+  val result = for {
+    response <- server.admin().setWorkflowsWhitelist(args.toList)
+    _ = logger.info(s"Raw response: ${ response.string }")
+    _ = logger.info(s"JSON AST: ${ response.json }")
+    _ = logger.info(s"JSON serialized: ${ Serialization.writePretty(response.json) }")
+//    data <- response.data
+//    _ = logger.info(s"Dataverse said: ${data.message}")
+  } yield ()
+  logger.info(s"result = $result")
 }

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/AdminApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/AdminApi.scala
@@ -172,4 +172,20 @@ class AdminApi private[dataverse](configuration: DataverseInstanceConfig) extend
     trace(triggerType)
     deletePath[DataMessage](s"workflows/default/$triggerType")
   }
+
+  /**
+   * @see [[https://guides.dataverse.org/en/latest/api/native-api.html#workflows]]
+   */
+  def setWorkflowsWhitelist(whilelist: String): Try[DataverseResponse[Any]] = {
+    trace(whilelist)
+    put[Any]("workflows/ip-whitelist", whilelist)
+  }
+
+  /**
+   * @see [[https://guides.dataverse.org/en/latest/api/native-api.html#workflows]]
+   */
+  def setWorkflowsWhitelist(ips: List[String]): Try[DataverseResponse[Any]] = {
+    trace(ips)
+    setWorkflowsWhitelist(ips.mkString(";"))
+  }
 }

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
@@ -34,6 +34,7 @@ import scala.util.{ Failure, Success, Try }
  */
 class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Boolean, configuration: DataverseInstanceConfig, workflowId: Option[String] = None) extends TargetedHttpSupport with DebugEnhancedLogging {
   private implicit val jsonFormats: Formats = DefaultFormats
+  private val HEADER_DATAVERSE_INVOCATION_ID = "X-Dataverse-invocationID"
 
   protected val connectionTimeout: Int = configuration.connectionTimeout
   protected val readTimeout: Int = configuration.readTimeout
@@ -49,7 +50,7 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
   protected val targetBase: String = "datasets"
   protected val id: String = datasetId
   protected val isPersistentId: Boolean = isPersistentDatasetId
-  override protected val extraHeaders: Map[String, String] = workflowId.map(wfid => Map("X-Dataverse-invocationID" -> wfid)).getOrElse(Map.empty)
+  override protected val extraHeaders: Map[String, String] = workflowId.map(wfid => Map(HEADER_DATAVERSE_INVOCATION_ID -> wfid)).getOrElse(Map.empty)
 
   /**
    * @see [[https://guides.dataverse.org/en/latest/api/native-api.html#get-json-representation-of-a-dataset]]

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
@@ -15,9 +15,6 @@
  */
 package nl.knaw.dans.lib.dataverse
 
-import java.lang.Thread.sleep
-import java.net.URI
-
 import better.files.File
 import nl.knaw.dans.lib.dataverse.model._
 import nl.knaw.dans.lib.dataverse.model.dataset.UpdateType.UpdateType
@@ -27,7 +24,9 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.json4s.native.Serialization
 import org.json4s.{ DefaultFormats, Formats }
 
-import scala.util.{ Failure, Try }
+import java.lang.Thread.sleep
+import java.net.URI
+import scala.util.{ Failure, Success, Try }
 
 /**
  * Functions that operate on a single dataset. See [[https://guides.dataverse.org/en/latest/api/native-api.html#datasets]].
@@ -44,8 +43,8 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
   protected val unblockKey: Option[String] = Option.empty
   protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
-  protected val awaitUnlockMaxNumberOfRetries: Int = configuration.awaitUnlockMaxNumberOfRetries
-  protected val awaitUnlockMillisecondsBetweenRetries: Int = configuration.awaitUnlockMillisecondsBetweenRetries
+  protected val awaitLockStateMaxNumberOfRetries: Int = configuration.awaitLockStateMaxNumberOfRetries
+  protected val awaitLockStateMillisecondsBetweenRetries: Int = configuration.awaitLockStateMillisecondsBetweenRetries
 
   protected val targetBase: String = "datasets"
   protected val id: String = datasetId
@@ -298,45 +297,13 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
    * to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset
    * it is not guaranteed that the locks, once cleared, stay that way.
    *
-   * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitUnlockMaxNumberOfRetries]]
-   * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitUnlockMillisecondsBetweenRetries]]
+   * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
+   * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitLockStateMillisecondsBetweenRetries]]
    * @return
-   * @throws LockException if after the maximum number of retries the dataset is still locked
    */
-  def awaitUnlock(maxNumberOfRetries: Int = awaitUnlockMaxNumberOfRetries, waitTimeInMilliseconds: Int = awaitUnlockMillisecondsBetweenRetries): Try[Unit] = {
+  def awaitUnlock(maxNumberOfRetries: Int = awaitLockStateMaxNumberOfRetries, waitTimeInMilliseconds: Int = awaitLockStateMillisecondsBetweenRetries): Try[Unit] = {
     trace(maxNumberOfRetries, waitTimeInMilliseconds)
-
-    def getCurrentLocks: Try[List[Lock]] = {
-      for {
-        response <- getLocks
-        locks <- response.data
-        _ = debug(s"Current locks: ${ locks.mkString(", ") }")
-      } yield locks
-    }
-
-    // Note: also returns false if a Failure occurred, i.e. the lock could not be confirmed. It seems reasonable that if an exception
-    // occurred that we stop trying and report the error.
-    def isLockConfirmed(maybeLocks: Try[List[Lock]]): Boolean = {
-      maybeLocks.map(_.nonEmpty).getOrElse(false)
-    }
-
-    def slept(): Boolean = {
-      debug(s"Sleeping $waitTimeInMilliseconds ms before next try..")
-      sleep(waitTimeInMilliseconds)
-      true
-    }
-
-    var numberOfTimesTried = 0
-    var maybeLocks = getCurrentLocks
-    do {
-      maybeLocks = getCurrentLocks
-      numberOfTimesTried += 1
-    } while (isLockConfirmed(maybeLocks) && numberOfTimesTried != maxNumberOfRetries && slept())
-
-    for {
-      locks <- maybeLocks
-      _ = if (locks.nonEmpty) throw LockException(numberOfTimesTried, waitTimeInMilliseconds, locks)
-    } yield ()
+    awaitLockState(_.isEmpty, "Wait for unlock expired")
   }
 
   /**
@@ -345,14 +312,29 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
    * to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been
    * locked on its behalf, so that it can be sure to have exclusive access via its invocation ID.
    *
-   * @param lockType the lock type to wait for
-   * @param maxNumberOfRetries the maximum number the check for unlock is made, defaults to [[awaitUnlockMaxNumberOfRetries]]
-   * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitUnlockMillisecondsBetweenRetries]]
-   * @throws LockException if after the maximum number of retries the lock type is still not encountered
+   * @param lockType               the lock type to wait for
+   * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitLockStateMaxNumberOfRetries]]
+   * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitLockStateMillisecondsBetweenRetries]]
    * @return
    */
-  def awaitLock(lockType: String, maxNumberOfRetries: Int = awaitUnlockMaxNumberOfRetries, waitTimeInMilliseconds: Int = awaitUnlockMillisecondsBetweenRetries): Try[Unit] = {
+  def awaitLock(lockType: String, maxNumberOfRetries: Int = awaitLockStateMaxNumberOfRetries, waitTimeInMilliseconds: Int = awaitLockStateMillisecondsBetweenRetries): Try[Unit] = {
     trace(maxNumberOfRetries, waitTimeInMilliseconds)
+    awaitLockState(_.exists(_.lockType == lockType), s"Wait for lock fo type $lockType expired")
+  }
+
+  /**
+   * Helper function that waits until the specified lockState function returns `true`, or throws a LockException if this never occurs
+   * within `maxNumberOrRetries` with `waitTimeInMilliseconds` pauses.
+   *
+   * @param lockState              the function that returns whether the required state has been reached
+   * @param errorMessage           error to report in LockException if it occurs
+   * @param maxNumberOfRetries     the maximum number of tries
+   * @param waitTimeInMilliseconds the time to wait between tries
+   * @return
+   */
+  private def awaitLockState(lockState: List[Lock] => Boolean, errorMessage: String, maxNumberOfRetries: Int = awaitLockStateMaxNumberOfRetries, waitTimeInMilliseconds: Int = awaitLockStateMillisecondsBetweenRetries): Try[Unit] = {
+    trace(maxNumberOfRetries, waitTimeInMilliseconds)
+    var numberOfTimesTried = 0
 
     def getCurrentLocks: Try[List[Lock]] = {
       for {
@@ -362,33 +344,22 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
       } yield locks
     }
 
-    // Note: also returns false if a Failure occurred, i.e. the lock could not be confirmed. It seems reasonable that if an exception
-    // occurred that we stop trying and report the error.
-    def isLockConfirmed(maybeLocks: Try[List[Lock]]): Boolean = {
-      maybeLocks.map(_.exists(_.lockType == lockType)).getOrElse(false)
-    }
-
     def slept(): Boolean = {
       debug(s"Sleeping $waitTimeInMilliseconds ms before next try..")
       sleep(waitTimeInMilliseconds)
       true
     }
 
-    var numberOfTimesTried = 0
     var maybeLocks = getCurrentLocks
     do {
       maybeLocks = getCurrentLocks
       numberOfTimesTried += 1
-    } while (isLockConfirmed(maybeLocks) && numberOfTimesTried != maxNumberOfRetries && slept())
+    } while (maybeLocks.isSuccess && !lockState(maybeLocks.get) && numberOfTimesTried != maxNumberOfRetries && slept())
 
-    for {
-      locks <- maybeLocks
-      _ = if (locks.nonEmpty) throw LockException(numberOfTimesTried, waitTimeInMilliseconds, locks)
-    } yield ()
-
-    ???
+    if (maybeLocks.isFailure) maybeLocks.map(_ => ())
+    else if (!lockState(maybeLocks.get)) Failure(LockException(numberOfTimesTried, waitTimeInMilliseconds, errorMessage))
+    else Success(())
   }
-
 
 
   /**

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
@@ -296,7 +296,7 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
    * Utility function that lets you wait until all locks are cleared before proceeding. Unlike most other functions
    * in this library, this does not correspond directly with an API call. Rather the [[getLocks]] call is done repeatedly
    * to check if the locks have been cleared. Note that in scenarios where concurrent processes might access the same dataset
-   * it is not guaranteed that the locks, once cleared, stayed that way.
+   * it is not guaranteed that the locks, once cleared, stay that way.
    *
    * @param maxNumberOfRetries     the maximum number the check for unlock is made, defaults to [[awaitUnlockMaxNumberOfRetries]]
    * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitUnlockMillisecondsBetweenRetries]]
@@ -338,6 +338,58 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
       _ = if (locks.nonEmpty) throw LockException(numberOfTimesTried, waitTimeInMilliseconds, locks)
     } yield ()
   }
+
+  /**
+   * Utility function that lets you wait until a specified lock type is set. Unlike most other functions
+   * in this library, this does not correspond directly with an API call. Rather the [[getLocks]] call is done repeatedly
+   * to check if the locks has been set. A use case is when an http/sr workflow wants to make sure that a dataset has been
+   * locked on its behalf, so that it can be sure to have exclusive access via its invocation ID.
+   *
+   * @param lockType the lock type to wait for
+   * @param maxNumberOfRetries the maximum number the check for unlock is made, defaults to [[awaitUnlockMaxNumberOfRetries]]
+   * @param waitTimeInMilliseconds the time between tries, defaults to [[awaitUnlockMillisecondsBetweenRetries]]
+   * @throws LockException if after the maximum number of retries the lock type is still not encountered
+   * @return
+   */
+  def awaitLock(lockType: String, maxNumberOfRetries: Int = awaitUnlockMaxNumberOfRetries, waitTimeInMilliseconds: Int = awaitUnlockMillisecondsBetweenRetries): Try[Unit] = {
+    trace(maxNumberOfRetries, waitTimeInMilliseconds)
+
+    def getCurrentLocks: Try[List[Lock]] = {
+      for {
+        response <- getLocks
+        locks <- response.data
+        _ = debug(s"Current locks: ${ locks.mkString(", ") }")
+      } yield locks
+    }
+
+    // Note: also returns false if a Failure occurred, i.e. the lock could not be confirmed. It seems reasonable that if an exception
+    // occurred that we stop trying and report the error.
+    def isLockConfirmed(maybeLocks: Try[List[Lock]]): Boolean = {
+      maybeLocks.map(_.exists(_.lockType == lockType)).getOrElse(false)
+    }
+
+    def slept(): Boolean = {
+      debug(s"Sleeping $waitTimeInMilliseconds ms before next try..")
+      sleep(waitTimeInMilliseconds)
+      true
+    }
+
+    var numberOfTimesTried = 0
+    var maybeLocks = getCurrentLocks
+    do {
+      maybeLocks = getCurrentLocks
+      numberOfTimesTried += 1
+    } while (isLockConfirmed(maybeLocks) && numberOfTimesTried != maxNumberOfRetries && slept())
+
+    for {
+      locks <- maybeLocks
+      _ = if (locks.nonEmpty) throw LockException(numberOfTimesTried, waitTimeInMilliseconds, locks)
+    } yield ()
+
+    ???
+  }
+
+
 
   /**
    * @see [[https://guides.dataverse.org/en/latest/api/native-api.html#dataset-locks]]

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DatasetApi.scala
@@ -33,7 +33,7 @@ import scala.util.{ Failure, Try }
  * Functions that operate on a single dataset. See [[https://guides.dataverse.org/en/latest/api/native-api.html#datasets]].
  *
  */
-class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Boolean, configuration: DataverseInstanceConfig) extends TargetedHttpSupport with DebugEnhancedLogging {
+class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Boolean, configuration: DataverseInstanceConfig, workflowId: Option[String] = None) extends TargetedHttpSupport with DebugEnhancedLogging {
   private implicit val jsonFormats: Formats = DefaultFormats
 
   protected val connectionTimeout: Int = configuration.connectionTimeout
@@ -50,6 +50,7 @@ class DatasetApi private[dataverse](datasetId: String, isPersistentDatasetId: Bo
   protected val targetBase: String = "datasets"
   protected val id: String = datasetId
   protected val isPersistentId: Boolean = isPersistentDatasetId
+  override protected val extraHeaders: Map[String, String] = workflowId.map(wfid => Map("X-Dataverse-invocationID" -> wfid)).getOrElse(Map.empty)
 
   /**
    * @see [[https://guides.dataverse.org/en/latest/api/native-api.html#get-json-representation-of-a-dataset]]

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstance.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstance.scala
@@ -33,8 +33,8 @@ class DataverseInstance(config: DataverseInstanceConfig) extends DebugEnhancedLo
     new DataverseApi(dvId: String, config)
   }
 
-  def dataset(pid: String): DatasetApi = {
-    new DatasetApi(pid, isPersistentDatasetId = true, config)
+  def dataset(pid: String, workflowId: Option[String] = None): DatasetApi = {
+    new DatasetApi(pid, isPersistentDatasetId = true, config, workflowId)
   }
 
   def dataset(id: Int): DatasetApi = {

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstanceConfig.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstanceConfig.scala
@@ -23,6 +23,6 @@ case class DataverseInstanceConfig(baseUrl: URI,
                                    connectionTimeout: Int = 5000,
                                    readTimeout: Int = 300000,
                                    apiVersion: String = "1",
-                                   awaitUnlockMaxNumberOfRetries: Int = 10,
-                                   awaitUnlockMillisecondsBetweenRetries: Int = 500
+                                   awaitLockStateMaxNumberOfRetries: Int = 10,
+                                   awaitLockStateMillisecondsBetweenRetries: Int = 500
                                   )

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/LockException.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/LockException.scala
@@ -22,7 +22,7 @@ import nl.knaw.dans.lib.dataverse.model.Lock
  *
  * @param numberOfTimesTried how many times the unlock check was tried
  * @param waitTimeInMilliseconds time waited between tries
- * @param locks list of locks found in last try
+ * @param msg message
  */
-case class LockException(numberOfTimesTried: Int, waitTimeInMilliseconds: Int, locks: List[Lock]) extends RuntimeException(s"Still locked after $numberOfTimesTried times with $waitTimeInMilliseconds millisecond pauses. Locks: ${ locks.mkString(", ") }")
+case class LockException(numberOfTimesTried: Int, waitTimeInMilliseconds: Int, msg: String) extends RuntimeException(s"$msg. Number of tries = $numberOfTimesTried, wait time between tries = $waitTimeInMilliseconds ms.")
 

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/TargetedHttpSupport.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/TargetedHttpSupport.scala
@@ -29,6 +29,7 @@ private[dataverse] trait TargetedHttpSupport extends HttpSupport {
   protected val targetBase: String
   protected val id: String
   protected val isPersistentId: Boolean
+  protected val extraHeaders: Map[String, String] = Map.empty
 
   /**
    * Get a specific version of something.
@@ -42,9 +43,11 @@ private[dataverse] trait TargetedHttpSupport extends HttpSupport {
     trace(endPoint, version)
     if (isPersistentId) super.get[D](
       subPath = s"${ targetBase }/:persistentId/versions/${ version }/${ endPoint }",
-      params = Map("persistentId" -> id))
+      params = Map("persistentId" -> id),
+      headers = extraHeaders)
     else super.get[D](
-      subPath = s"${ targetBase }/$id/versions/${ version }/${ endPoint }")
+      subPath = s"${ targetBase }/$id/versions/${ version }/${ endPoint }",
+      headers = extraHeaders)
   }
 
   /**
@@ -58,20 +61,24 @@ private[dataverse] trait TargetedHttpSupport extends HttpSupport {
     trace(endPoint)
     if (isPersistentId) super.get[D](
       subPath = s"${ targetBase }/:persistentId/${ endPoint }",
-      params = Map("persistentId" -> id))
+      params = Map("persistentId" -> id),
+      headers = extraHeaders)
     else super.get[D](
-      subPath = s"${ targetBase }/$id/${ endPoint }")
+      subPath = s"${ targetBase }/$id/${ endPoint }",
+      headers = extraHeaders)
   }
 
   protected def postJsonToTarget[D: Manifest](endPoint: String, body: String, queryParams: Map[String, String] = Map.empty): Try[DataverseResponse[D]] = {
     if (isPersistentId) super.postJson[D](
       subPath = s"${ targetBase }/:persistentId/${ endPoint }",
       body,
-      params = Map("persistentId" -> id) ++ queryParams)
+      params = Map("persistentId" -> id) ++ queryParams,
+      headers = extraHeaders)
     else super.postJson[D](
       subPath = s"${ targetBase }/$id/${ endPoint }",
       body,
-      params = queryParams)
+      params = queryParams,
+      headers = extraHeaders)
   }
 
   protected def postFileToTarget[D: Manifest](endPoint: String, optFile: Option[File], optMetadata: Option[String], queryParams: Map[String, String] = Map.empty): Try[DataverseResponse[D]] = {
@@ -79,30 +86,36 @@ private[dataverse] trait TargetedHttpSupport extends HttpSupport {
       subPath = s"${ targetBase }/:persistentId/${ endPoint }",
       optFile,
       optMetadata,
-      params = Map("persistentId" -> id) ++ queryParams)
+      params = Map("persistentId" -> id) ++ queryParams,
+      headers = extraHeaders)
     else super.postFile[D](
       subPath = s"${ targetBase }/$id/${ endPoint }",
       optFile,
       optMetadata,
-      params = queryParams)
+      params = queryParams,
+      headers = extraHeaders)
   }
 
   protected def putToTarget[D: Manifest](endPoint: String, body: String, queryParams: Map[String, String] = Map.empty): Try[DataverseResponse[D]] = {
     if (isPersistentId) super.put[D](
       subPath = s"${ targetBase }/:persistentId/${ endPoint }",
       body,
-      params = Map("persistentId" -> id) ++ queryParams)
+      params = Map("persistentId" -> id) ++ queryParams,
+      headers = extraHeaders)
     else super.put[D](
       subPath = s"${ targetBase }/$id/${ endPoint }",
       body,
-      params = queryParams)
+      params = queryParams,
+      headers = extraHeaders)
   }
 
   protected def deleteAtTarget[D: Manifest](endPoint: String): Try[DataverseResponse[D]] = {
     if (isPersistentId) super.deletePath[D](
       subPath = s"${ targetBase }/:persistentId/${ endPoint }",
-      params = Map("persistentId" -> id))
+      params = Map("persistentId" -> id),
+      headers = extraHeaders)
     else super.put[D](
-      subPath = s"${ targetBase }/$id/${ endPoint }")
+      subPath = s"${ targetBase }/$id/${ endPoint }",
+      headers = extraHeaders)
   }
 }

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/model/Lock.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/model/Lock.scala
@@ -18,4 +18,4 @@ package nl.knaw.dans.lib.dataverse.model
 case class Lock(lockType: String,
                 date: String,
                 user: String,
-                message: String)
+                message: Option[String] = None)


### PR DESCRIPTION
Fixes DD-334

# Description of changes
* Added an optional lock override parameter to the DatasetApi. When provided, all calls to the the functions of DatasetApi will send it as the value of the `X-Dataverse-invocationID` header. This has the effect of overriding the dataset lock in Dataverse version that include https://github.com/IQSS/dataverse/pull/7568. 
* Added API calls for setting resume whitelist IPs.
* Added `awaitLock` and refactored `awaitUnlock`.


# How to test
1. Make sure you are running a version of Dataverse that includes https://github.com/IQSS/dataverse/pull/7568
2. Create an http/sr workflow and configure it to be triggered on prepublication.
3. Make sure your workflow logs the invocation ID.
4. Create a dataset and publish it. The dataset will get locked and the invocation ID is in your workflow's lock.
5. Use examples/src/main/scala/nl/knaw/dans/examples/EditDatasetMetadata.scala to edit the metadata providing the invocation ID as lock override key.

# Related PRs 
* https://github.com/IQSS/dataverse/pull/7568

# Notify
@DANS-KNAW/dataversedans
