### PR TITLE
Adding an example to replace file with prestaged file

### DIFF
--- a/examples/src/main/scala/nl/knaw/dans/examples/ReplaceFileWithPrestaged.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/ReplaceFileWithPrestaged.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.examples
+
+import nl.knaw.dans.lib.dataverse.model.file.prestaged.Checksum
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.json4s.native.Serialization
+import org.json4s.{ DefaultFormats, Formats }
+
+/**
+ * Before executing this code you must create the replacement file at
+ *
+ * s3://bucket-name/DOI-of-dataset/storage-identifier
+ *
+ * with appropriate values for bucket-name, DOI-of-dataset and storage-identifier.
+ *
+ * Not tested for file storage, but that should work similarly.
+ *
+ */
+object ReplaceFileWithPrestaged extends App with DebugEnhancedLogging with BaseApp {
+  private implicit val jsonFormats: Formats = DefaultFormats
+  private val doi = args(0)
+  private val databaseId = args(1).toInt
+  private val storageId = args(2)
+  private val sha1Checksum = args(3) // Checksum of the replacement
+  private val fileSize = args(4).toInt // Length of the replacement
+
+  val result = for {
+    response <- server.dataset(doi).listFiles()
+    fileMetas <- response.data
+    dataFile = fileMetas.map(_.dataFile).find(_.exists(_.id == databaseId)).flatten.get
+    newDataFile = dataFile.toPrestaged.copy(storageIdentifier = storageId, checksum = Checksum(`@type` = "SHA-1", `@value` = sha1Checksum), fileSize = fileSize)
+    response <- server.file(databaseId).replaceWithPrestagedFile(newDataFile)
+    _ = logger.info(s"Raw response message: ${ response.string }")
+    _ = logger.info(s"JSON AST: ${ response.json }")
+    _ = logger.info(s"JSON serialized: ${ Serialization.writePretty(response.json) }")
+    fileList <- response.data
+    _ = logger.info(s"File has ${ fileList.files.head.dataFile.get.checksum.`type` } checksum ${ fileList.files.head.dataFile.get.checksum.value }")
+  } yield ()
+  logger.info(s"result = $result")
+}

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/FileApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/FileApi.scala
@@ -112,7 +112,7 @@ class FileApi private[dataverse](filedId: String, isPersistentFileId: Boolean, c
   /**
    * Replaces a file with a pre-staged file using a slightly modified JSON for DataFile.
    *
-   * TODO: Add pointer to documentation once this is published
+   * @see [[https://guides.dataverse.org/en/latest/developers/s3-direct-upload-api.html#replacing-an-existing-file-in-the-dataset]]
    *
    * @param prestagedFile a prestaged.DataFile object
    * @return


### PR DESCRIPTION
Fixes DD-468

# Description of changes
* Added an example for `FilesApi.replaceWithPrestaged` (the function itself had been merged previously)

# How to test
1. Create a dataset.
2. Add a file to it. Find its database ID in the file metadata.
3. Publish dataset.
4. Upload a replacement file directly to the object store:
    ```
    aws s3 cp <location-of-replacement-on-laptop> \
       s3://<bucket>/<doi-namespace>/<doi-shoulder>/<doi-suffix>/<storage-id-numeric-part>
    ```
    for example:
    ```
    aws s3 cp /Users/janm/Downloads/replace-test/file-replacement.jpg \
        s3://testbucket-archaeology/10.5072/DAR/EBREJ2/179e0ce5959-897b0aec6cb9 \
        --profile local
    ```
    You must make a number for `<storage-id-numeric-part>` yourself; just find the corresponding number for the 
    file to be replaced and change one digit.
5. Determine the SHA-1 and the size of the replacement file:
    ```
    shasum /Users/janm/Downloads/replace-test/file-replacement.jpg
    ls -l /Users/janm/Downloads/replace-test/file-replacement.jpg
    ```
6. Run the example `nl.knaw.dans.examples.ReplaceFileWithPrestaged` with the correct command line arguments, for
   example: 
   ```
   doi:10.5072/DAR/EBREJ2 4 s3://Testbucket-Archaeology:179e0ce5959-897b0aec6cb9 8cf9a8e8a3acd3ed0ece180be4c5aacaeab87e44 219647
   # <doi-of-dataset> <db-id-of-orginal-file>  <complete-storage-id-of-prestaged-replacement> <sha1-of-replacement> <length-of-replacement>
   ```
**Note: the storage ID of objectstore has the following structure: `s3://<bucket>:<numeric-part>` (the DOI is not part of it)**


# Related PRs 
(Add links)
* 

# Notify
@DANS-KNAW/dataversedans
