### PR TITLE
DD-472 Implement mapping of file accessibility

### DIFF
--- a/examples/src/main/scala/nl/knaw/dans/examples/EnableAccessRequests.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/EnableAccessRequests.scala
@@ -31,6 +31,8 @@ object EnableAccessRequests extends App with DebugEnhancedLogging with BaseApp {
     _ = logger.info(s"Raw response message: ${ response.string }")
     _ = logger.info(s"JSON AST: ${ response.json }")
     _ = logger.info(s"JSON serialized: ${ Serialization.writePretty(response.json) }")
+    msg <- response.data
+    _ = logger.info(s"Dataverse says '${msg.message}'")
   } yield ()
   logger.info(s"result = $result")
 }

--- a/examples/src/main/scala/nl/knaw/dans/examples/EnableAccessRequests.scala
+++ b/examples/src/main/scala/nl/knaw/dans/examples/EnableAccessRequests.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2020 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.examples
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.json4s.native.Serialization
+import org.json4s.{ DefaultFormats, Formats }
+
+object EnableAccessRequests extends App with DebugEnhancedLogging with BaseApp {
+  private implicit val jsonFormats: Formats = DefaultFormats
+  private val persistentId = args(0)
+  private val enable = if (args.length > 1) args(1) == "enable"
+                        else false
+
+  val result = for {
+    response <- if (enable) server.accessRequests(persistentId).enable()
+                else server.accessRequests(persistentId).disable()
+    _ = logger.info(s"Raw response message: ${ response.string }")
+    _ = logger.info(s"JSON AST: ${ response.json }")
+    _ = logger.info(s"JSON serialized: ${ Serialization.writePretty(response.json) }")
+  } yield ()
+  logger.info(s"result = $result")
+}

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataAccessApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataAccessApi.scala
@@ -35,4 +35,7 @@ class DataAccessApi private[dataverse](filedId: String, isPersistentFileId: Bool
   override protected val targetBase: String = "datafiles"
   override protected val id: String = filedId
   override protected val isPersistentId: Boolean = isPersistentFileId
+
+
+  // TODO: implement the end points that target files.
 }

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataAccessRequestsApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataAccessRequestsApi.scala
@@ -19,8 +19,9 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.json4s.{ DefaultFormats, Formats }
 
 import java.net.URI
+import scala.util.Try
 
-class DataAccessApi private[dataverse](filedId: String, isPersistentFileId: Boolean, configuration: DataverseInstanceConfig) extends TargetedHttpSupport with DebugEnhancedLogging {
+class DataAccessRequestsApi private[dataverse](datasetId: String, isPersistentFileId: Boolean, configuration: DataverseInstanceConfig) extends TargetedHttpSupport with DebugEnhancedLogging {
   trace(())
   private implicit val jsonFormats: Formats = DefaultFormats
 
@@ -30,9 +31,19 @@ class DataAccessApi private[dataverse](filedId: String, isPersistentFileId: Bool
   protected val apiToken: Option[String] = Option(configuration.apiToken)
   protected val sendApiTokenViaBasicAuth = false
   protected val unblockKey: Option[String] = Option.empty
-  protected val apiPrefix: String = "api/access"
+  protected val apiPrefix: String = "api"
   protected val apiVersion: Option[String] = Option(configuration.apiVersion)
-  override protected val targetBase: String = "datafiles"
-  override protected val id: String = filedId
+  override protected val targetBase: String = "access"
+  override protected val id: String = datasetId
   override protected val isPersistentId: Boolean = isPersistentFileId
+
+  def enable(): Try[DataverseResponse[Any]] = {
+    trace(())
+    putToTarget("allowAccessRequest", "true")
+  }
+
+  def disable(): Try[DataverseResponse[Any]] = {
+    trace(())
+    putToTarget("allowAccessRequest", "false")
+  }
 }

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataAccessRequestsApi.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataAccessRequestsApi.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.lib.dataverse
 
+import nl.knaw.dans.lib.dataverse.model.{ DataMessage, DataverseMessage }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.json4s.{ DefaultFormats, Formats }
 
@@ -37,12 +38,24 @@ class DataAccessRequestsApi private[dataverse](datasetId: String, isPersistentFi
   override protected val id: String = datasetId
   override protected val isPersistentId: Boolean = isPersistentFileId
 
-  def enable(): Try[DataverseResponse[Any]] = {
+  /**
+   * Enables access requests for the targetted dataset
+   *
+   * @see [[https://guides.dataverse.org/en/latest/api/dataaccess.html#allow-access-requests]]
+   * @return
+   */
+  def enable(): Try[DataverseResponse[DataMessage]] = {
     trace(())
     putToTarget("allowAccessRequest", "true")
   }
 
-  def disable(): Try[DataverseResponse[Any]] = {
+  /**
+   * Disables access requests for the targettted dataset
+   *
+   * @see [[https://guides.dataverse.org/en/latest/api/dataaccess.html#allow-access-requests]]
+   * @return
+   */
+  def disable(): Try[DataverseResponse[DataMessage]] = {
     trace(())
     putToTarget("allowAccessRequest", "false")
   }

--- a/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstance.scala
+++ b/lib/src/main/scala/nl.knaw.dans.lib.dataverse/DataverseInstance.scala
@@ -68,4 +68,20 @@ class DataverseInstance(config: DataverseInstanceConfig) extends DebugEnhancedLo
   def search(): SearchApi = {
     new SearchApi(config)
   }
+
+  def access(pid: String): DataAccessApi = {
+    new DataAccessApi(pid, isPersistentFileId = true, config)
+  }
+
+  def access(id: Int): DataAccessApi = {
+    new DataAccessApi(id.toString, isPersistentFileId = false, config)
+  }
+
+  def accessRequests(pid: String): DataAccessRequestsApi = {
+    new DataAccessRequestsApi(pid, isPersistentFileId = true, config)
+  }
+
+  def accessAccessRequests(id: Int): DataAccessRequestsApi = {
+    new DataAccessRequestsApi(id.toString, isPersistentFileId = false, config)
+  }
 }


### PR DESCRIPTION
Fixes DD-472

# Description of changes
* Added `DataAccessApi` and `DataAccessRequestsApi` that together should eventually cover the [data access API](https://guides.dataverse.org/en/latest/api/dataaccess.html). Two classes, because the way the library is set up one class can target specific base URL, for example a dataset. Enabling access requests targets a dataset, the other endpoints of the access API target files.
* Added and example that lets you enable or disable access requests through the API.


# How to test


# Related PRs 
* https://github.com/DANS-KNAW/dd-dans-deposit-to-dataverse/pull/62

# Notify
@DANS-KNAW/dataversedans
